### PR TITLE
Add support for @Listener

### DIFF
--- a/src/main/java/org/tldgen/annotations/Listener.java
+++ b/src/main/java/org/tldgen/annotations/Listener.java
@@ -1,0 +1,13 @@
+package org.tldgen.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+public @interface Listener {
+}

--- a/src/main/java/org/tldgen/factory/LibraryFactory.java
+++ b/src/main/java/org/tldgen/factory/LibraryFactory.java
@@ -1,17 +1,17 @@
 package org.tldgen.factory;
 
-import static org.tldgen.util.JavadocUtils.getAnnotation;
-
+import com.sun.javadoc.AnnotationDesc;
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.MethodDoc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tldgen.model.Function;
 import org.tldgen.model.Library;
 import org.tldgen.model.LibrarySignature;
+import org.tldgen.model.Listener;
 import org.tldgen.model.Tag;
 
-import com.sun.javadoc.AnnotationDesc;
-import com.sun.javadoc.ClassDoc;
-import com.sun.javadoc.MethodDoc;
+import static org.tldgen.util.JavadocUtils.getAnnotation;
 
 /**
  * Creates a {@link Library} instance from the javadoc information
@@ -31,8 +31,11 @@ public class LibraryFactory {
 		Library library = new Library(librarySignature);
 		for (ClassDoc clazz : classes) {
         	Tag tag = parseTag(clazz);
+        	Listener listener = parseListener(clazz);
         	if (tag != null) {
         		library.add(tag);
+        	} else if(listener != null) {
+        		library.addListener(listener);
         	} else {
         		recollectFunctionData(clazz, library);
         	}
@@ -48,6 +51,15 @@ public class LibraryFactory {
 	 */
 	private Tag parseTag(ClassDoc doc) {
 		return !doc.isAbstract() && getAnnotation(doc, org.tldgen.annotations.Tag.class) != null? Tag.createInstance(doc) : null;
+	}
+
+	/**
+	 * Parse the Listener from this class annotation
+	 * @param doc the javadoc to parse
+	 * @return the Listener class parsed for the provided class, null if none
+	 */
+	private Listener parseListener(ClassDoc doc) {
+		return !doc.isAbstract() && getAnnotation(doc, org.tldgen.annotations.Listener.class) != null? Listener.createInstance(doc) : null;
 	}
 
 	

--- a/src/main/java/org/tldgen/model/Library.java
+++ b/src/main/java/org/tldgen/model/Library.java
@@ -19,6 +19,9 @@ public class Library {
 	/** list of functions in this library */
 	private Set<Function> functions = new TreeSet<Function>();
 
+	/** list of listeners in this library */
+	private Set<Listener> listeners = new TreeSet<Listener>();
+
 	public Library(LibrarySignature librarySignature) {
 		this.librarySignature = librarySignature;
 	}
@@ -48,6 +51,20 @@ public class Library {
 		}
 		return null;
 	}
+
+	/**
+	 * Convenience method to get a listener by class name
+	 *
+	 * @return the listener with the matching class name, null if none was found
+	 */
+	public Listener getListener(String name) {
+		for (Listener listener : listeners) {
+			if (name.equals(listener.getListenerClass())) {
+				return listener;
+			}
+		}
+		return null;
+	}
 	
 	public void add(Tag tag) {
 		tags.add(tag);
@@ -56,13 +73,21 @@ public class Library {
 	public void add(Function function) {
 		functions.add(function);
 	}
-	
+
+	public void addListener(Listener listener) {
+		listeners.add(listener);
+	}
+
 	public Set<Tag> getTags() {
 		return tags;
 	}
 
 	public Set<Function> getFunctions() {
 		return functions;
+	}
+
+	public Set<Listener> getListeners() {
+		return listeners;
 	}
 
 	public LibrarySignature getLibrarySignature() {

--- a/src/main/java/org/tldgen/model/Listener.java
+++ b/src/main/java/org/tldgen/model/Listener.java
@@ -1,0 +1,41 @@
+package org.tldgen.model;
+
+import com.sun.javadoc.AnnotationDesc;
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.Doc;
+
+import static org.tldgen.util.JavadocUtils.getAnnotation;
+
+public class Listener extends AbstractTldElement {//implements Comparable<Listener>{
+
+    private String listenerClass;
+
+    public String getListenerClass() {
+        return listenerClass;
+    }
+
+    public void setListenerClass(String listenerClass) {
+        this.listenerClass = listenerClass;
+        this.setName(parseSimpleName());
+    }
+
+    public static Listener createInstance(ClassDoc doc) {
+        Listener listener = new Listener();
+        AnnotationDesc ann = getAnnotation(doc, org.tldgen.annotations.Listener.class);
+        ClassDoc classDoc = (ClassDoc) doc;
+        listener.setListenerClass(classDoc.qualifiedTypeName());
+        listener.setName(listener.listenerClass);
+        listener.postProcessElement(doc, ann);
+        return listener;
+    }
+
+    @Override
+    protected String calculateDefaultElementName(Doc doc) {
+      return parseSimpleName();
+    }
+
+    private String parseSimpleName() {
+      int startIndex = listenerClass.lastIndexOf(".");
+      return startIndex > 0 ? listenerClass.substring(++startIndex) : listenerClass;
+    }
+}

--- a/src/main/java/org/tldgen/writers/AbstractHtmlWriter.java
+++ b/src/main/java/org/tldgen/writers/AbstractHtmlWriter.java
@@ -1,12 +1,13 @@
 package org.tldgen.writers;
 
-import java.io.IOException;
-import java.io.StringWriter;
-
 import org.tldgen.model.AbstractTldElement;
 import org.tldgen.model.Function;
 import org.tldgen.model.Library;
+import org.tldgen.model.Listener;
 import org.tldgen.model.Tag;
+
+import java.io.IOException;
+import java.io.StringWriter;
 
 /**
  * Create a single HTML file
@@ -88,6 +89,9 @@ public abstract class AbstractHtmlWriter extends AbstractWriter {
 		if (!library.getFunctions().isEmpty()) {
 			printMenuItem("functions.html", "functions", selectedItem instanceof Function);
 		}
+    if (!library.getListeners().isEmpty()) {
+      printMenuItem("listeners.html", "listeners", selectedItem instanceof Listener);
+    }
 		endTag("ol");
 		endTag("div");
 		endTag("div");

--- a/src/main/java/org/tldgen/writers/HtmlLibraryWriter.java
+++ b/src/main/java/org/tldgen/writers/HtmlLibraryWriter.java
@@ -1,18 +1,18 @@
 package org.tldgen.writers;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.MalformedURLException;
-
 import org.apache.commons.io.IOUtils;
 import org.tldgen.DocletOptions;
 import org.tldgen.model.Library;
 import org.tldgen.model.Tag;
 import org.tldgen.util.ClasspathFileUtils;
 import org.tldgen.util.DirectoryUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
 
 /**
  * Create HTML Documentation
@@ -53,6 +53,13 @@ public class HtmlLibraryWriter {
 			functionWriter.write(library);
 			functionWriter.close();		
 		}
+
+    if (!library.getListeners().isEmpty()) {
+      HtmlListenerWriter listenerWriter = new HtmlListenerWriter(htmlFolder + "/listeners.html");
+      listenerWriter.setFormatOutput(formatOutput);
+      listenerWriter.write(library);
+      listenerWriter.close();
+    }
 	}
 
 	/**

--- a/src/main/java/org/tldgen/writers/HtmlListenerWriter.java
+++ b/src/main/java/org/tldgen/writers/HtmlListenerWriter.java
@@ -1,0 +1,83 @@
+package org.tldgen.writers;
+
+import org.tldgen.model.Library;
+import org.tldgen.model.Listener;
+
+import java.io.IOException;
+
+public class HtmlListenerWriter extends AbstractHtmlWriter {
+
+  public HtmlListenerWriter(String htmlFile) throws IOException {
+    super(htmlFile);
+  }
+
+
+  /**
+   * Fill the HTML main content with Tag information
+   * @param listener {@link org.tldgen.model.Listener}
+   */
+  /*private void writeListener(Listener listener) throws IOException{
+
+    String description = listener.getHtmlDescription();
+
+    startTag("p").print(description).endTag("p");
+
+    startTag("table", "class", "tag-info");
+    startTag("thead");
+    startTag("tr");
+    startTag("th", "colspan", "2").print("Listener Information").endTag("th");
+    endTag("tr");
+    endTag("thead");
+    startTag("tbody");
+    printTableEntry("Listener Class", listener.getListenerClass());
+    endTag("tbody");
+    endTag("table");
+  }*/
+
+  /**
+   * Fill the HTML main content with Listener information
+   * @param listener {@link Listener}
+   * @throws IOException
+   */
+  private void writeListener(Listener listener) throws IOException {
+
+    printHeader(2, listener.getName());
+    print(listener.getHtmlDescription());
+    startTag("table");
+    startTag("tbody");
+    writeInfo(listener);
+    endTag("tbody");
+    endTag("table");
+  }
+
+  /**
+   * Write content of the Function information
+   * @param listener {@link org.tldgen.model.Listener}
+   * @throws IOException
+   */
+  private void writeInfo(Listener listener) throws IOException {
+    printTableEntry("Listener Class", listener.getListenerClass());
+  }
+
+  /**
+   * @param library the library data model to process
+   */
+  public void write(Library library) throws IOException{
+    startDocument("Listeners");
+    startBody();
+
+    printHeader(1, "Listeners");
+
+    for (Listener listener: library.getListeners()) {
+      startTag("div", "id", listener.getName(), "class","yui-g bottom-delimiter");
+      writeListener(listener);
+      endTag("div");
+    }
+
+    printMenu(library, library.getListeners().iterator().next());
+
+    endBody("Listeners");
+    endDocument();
+  }
+
+}

--- a/src/main/java/org/tldgen/writers/TldLibraryWriter.java
+++ b/src/main/java/org/tldgen/writers/TldLibraryWriter.java
@@ -1,15 +1,5 @@
 package org.tldgen.writers;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Collection;
-import java.util.Set;
-
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,9 +10,19 @@ import org.tldgen.model.Attribute;
 import org.tldgen.model.Function;
 import org.tldgen.model.Library;
 import org.tldgen.model.LibrarySignature;
+import org.tldgen.model.Listener;
 import org.tldgen.model.Tag;
 import org.tldgen.model.Variable;
 import org.tldgen.util.DirectoryUtils;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * Create TLD documentation
@@ -66,6 +66,11 @@ public class TldLibraryWriter extends AbstractWriter {
 			if (library.getFunctions() != null) {
 				writeFunctions(library.getFunctions());
 			}
+
+			if(library.getListeners() != null) {
+				writeListeners(library.getListeners());
+			}
+
 			endTaglibElement();
 		} finally {
 			if (writer != null) {
@@ -180,6 +185,21 @@ public class TldLibraryWriter extends AbstractWriter {
 	}
 
 	/**
+	 * Write the listeners to the tld file
+	 *
+	 * @param listeners the listeners to include in the tld file
+	 * @throws XMLStreamException on error writing to out stream
+	 */
+	private void writeListeners(Set<Listener> listeners)
+		throws XMLStreamException {
+		for(Listener listener : listeners) {
+			log.debug("writing Listener for '"+listener.getListenerClass() +"'");
+			startElement("listener");
+			writeElement("listener-class", listener.getListenerClass());
+			endElement();
+		}
+	}
+	/**
 	 * Write the Attributes info
 	 * 
 	 * @param attributes {@link Attribute} instances to write to the TLD
@@ -194,7 +214,6 @@ public class TldLibraryWriter extends AbstractWriter {
 			writeElement("name", attr.getName());
 			writeElement("required", attr.isRequired()? attr.isRequired() : null);
 			writeElement("rtexprvalue", attr.isRtexprvalue()? attr.isRtexprvalue() : null);
-
 			endElement();
 		}
 	}

--- a/src/test/java/org/tldgen/factory/LibraryFactoryTest.java
+++ b/src/test/java/org/tldgen/factory/LibraryFactoryTest.java
@@ -1,11 +1,6 @@
 package org.tldgen.factory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
+import com.sun.tools.javadoc.Main;
 import org.junit.Before;
 import org.junit.Test;
 import org.tldgen.TldDoclet;
@@ -14,10 +9,15 @@ import org.tldgen.model.Attribute;
 import org.tldgen.model.Function;
 import org.tldgen.model.FunctionParameter;
 import org.tldgen.model.Library;
+import org.tldgen.model.Listener;
 import org.tldgen.model.Tag;
 import org.tldgen.tags.DummyTei;
 
-import com.sun.tools.javadoc.Main;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test the Parser class by launching javadoc and retrieving the parse results
@@ -128,7 +128,18 @@ public class LibraryFactoryTest {
 		assertNull(library.getFunction("hidden"));
 		
 	}
-	
+
+    @Test
+    public void testListeners() {
+
+        Listener dummy = library.getListener("org.tldgen.tags.DummyListener");
+        assertNotNull(dummy);
+        assertNotNull(dummy.getListenerClass());
+        assertEquals("org.tldgen.tags.DummyListener", dummy.getListenerClass());
+
+        assertEquals(1, library.getListeners().size());
+
+    }
 	private Attribute getAttribute(Tag tag, String name) {
 		for (Attribute attribute : tag.getAttributes()) {
 			if (attribute.getName().equals(name)) {

--- a/src/test/java/org/tldgen/mock/MockLibraryFactory.java
+++ b/src/test/java/org/tldgen/mock/MockLibraryFactory.java
@@ -7,6 +7,7 @@ import org.tldgen.model.Function;
 import org.tldgen.model.FunctionParameter;
 import org.tldgen.model.Library;
 import org.tldgen.model.LibrarySignature;
+import org.tldgen.model.Listener;
 import org.tldgen.model.Tag;
 import org.tldgen.model.Variable;
 
@@ -82,6 +83,11 @@ public class MockLibraryFactory {
 		function.setClazz("org.tldgen.targetfunctions.FunctionSampleUtil");
 		function.setReturnDescription("Returns true if the argument is 42, false otherwise. Go figure.");
 		library.add(function);
+
+    Listener listener = new Listener();
+    listener.setListenerClass("org.tldgen.listeners.DummyListener");
+    listener.setDescription("A Listener created for testing");
+    library.addListener(listener);
 
 		return library;
 	}

--- a/src/test/java/org/tldgen/tags/DummyListener.java
+++ b/src/test/java/org/tldgen/tags/DummyListener.java
@@ -1,0 +1,10 @@
+package org.tldgen.tags;
+
+import org.tldgen.annotations.Listener;
+
+/**
+ * A dummy listener for testing.
+ */
+@Listener
+public class DummyListener {
+}

--- a/src/test/resources/org/tldgen/writers/expected-output.tld
+++ b/src/test/resources/org/tldgen/writers/expected-output.tld
@@ -59,4 +59,7 @@
         <function-signature>java.lang.String function0(int param1)</function-signature>
         <example>function1 example</example>
     </function>
+    <listener>
+        <listener-class>org.tldgen.listeners.DummyListener</listener-class>
+    </listener>
 </taglib>


### PR DESCRIPTION
Add support for a new "Listener" annotation which will result in the listener class being added to the generated TLD and included in the generated docs.

There is no support for validation of the @Listener annotated class implements `javax.servlet.*Listener` as the annotated class may inherit from a class implementing `javax.servlet.*Listener`. The parent class source may not be available during javadoc processing.
