### PR TITLE
Generates invalid TLD file by @Variable

### DIFF
--- a/src/main/java/org/tldgen/writers/TldLibraryWriter.java
+++ b/src/main/java/org/tldgen/writers/TldLibraryWriter.java
@@ -153,8 +153,8 @@ public class TldLibraryWriter extends AbstractWriter {
 			writeElement("tag-class", tag.getClazz());
 			writeElement("tei-class", tag.getTeiClass());
 			writeElement("body-content", tag.getBodyContent().getTldValue());
-			writeTagAttributes(tag.getName(), tag.getAttributes());
 			writeTagVariables(tag.getName(), tag.getVariables());
+			writeTagAttributes(tag.getName(), tag.getAttributes());
 			writeElement("dynamic-attributes", tag.isDynamicAttributes()? tag.isDynamicAttributes() : null);
 			writeElement("example", tag.getExample());
 			endElement();

--- a/src/test/resources/org/tldgen/writers/expected-output.tld
+++ b/src/test/resources/org/tldgen/writers/expected-output.tld
@@ -24,14 +24,14 @@
         <name>dummy</name>
         <tag-class>org.tldgen.sample.DummyTag</tag-class>
         <body-content>empty</body-content>
+        <variable>
+            <name-given>foo</name-given>
+        </variable>
         <attribute>
             <name>foo</name>
             <required>true</required>
             <type>java.lang.Boolean</type>
         </attribute>
-        <variable>
-            <name-given>foo</name-given>
-        </variable>
         <example>dummy example</example>
     </tag>
     <tag>


### PR DESCRIPTION
According to TLD XMLSchema <variable> elements must not be appeared after <attribute> elements.
