### PR TITLE
Released tldgen-1.4.4.jar contains problematic unnecessary unit test generated TLD files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .gradle/
 build/
 src/test/genlib/
-src/main/resources/META-INF/
 target
 .settings
 .classpath

--- a/src/test/java/org/tldgen/factory/LibraryAnnotationTest.java
+++ b/src/test/java/org/tldgen/factory/LibraryAnnotationTest.java
@@ -25,7 +25,7 @@ public class LibraryAnnotationTest {
 	public void setup() {
 		TldDoclet.reset();
 		int result = Main.execute(new String[] {
-				"-private", "-doclet", TldDoclet.class.getName(), "-sourcepath", "src/test/java", "org.tldgen.libtags", "-tldFile", OUTPUT_FOLDER + "LibraryAnnotationTest-output/tldgen-test.tld",
+				"-private", "-doclet", TldDoclet.class.getName(), "-sourcepath", "src/test/java", "org.tldgen.libtags", "-tldFolder", OUTPUT_FOLDER + "LibraryAnnotationTest-output",
 				"-htmlFolder", OUTPUT_FOLDER + "LibraryAnnotationTest-output"
 		});
 		assertEquals("The javadoc command did not exit successfully. Check the system log for details", 0, result);

--- a/src/test/java/org/tldgen/factory/LibraryFactoryTest.java
+++ b/src/test/java/org/tldgen/factory/LibraryFactoryTest.java
@@ -33,7 +33,7 @@ public class LibraryFactoryTest {
 	@Before
 	public void setup() {
 		int result = Main.execute(new String[] {
-				"-private", "-doclet", TldDoclet.class.getName(), "-sourcepath", "src/test/java", "org.tldgen.tags", "-tldFile", OUTPUT_FOLDER + "LibraryFactoryTest-output/tldgen-test.tld",
+				"-private", "-doclet", TldDoclet.class.getName(), "-sourcepath", "src/test/java", "org.tldgen.tags", "-tldFolder", OUTPUT_FOLDER + "LibraryFactoryTest-output",
 				"-displayName", "Loom Core Tag Library", "-name", "loom", "-uri", "http://loom.extrema-sistemas.org/loom-core.tld", "-htmlFolder", OUTPUT_FOLDER + "LibraryFactoryTest-output", 
 				"-indentSpaces", "4", "-license", "APACHE", "-version", "2.1"
 		});


### PR DESCRIPTION
I'm using SpringBoot's SpringApplication on Eclipse for my web application.
This execution environment cannot exclude non-runtime dependencies from classpath, the released tldgen-1.4.4.jar on maven repository contains META-INF/foobar.tld and META-INF/loom.tld.

Then the web container discovers these dummy TLD files, it try to load unavailable classes, that causes unrecoverable error consequently.